### PR TITLE
Fix initialization warning

### DIFF
--- a/driver/src/global/xaiegbl.h
+++ b/driver/src/global/xaiegbl.h
@@ -765,7 +765,7 @@ static inline void XAie_SetupConfigPartProp(XAie_Config *ConfigPtr, u32 Nid,
 *		more memory from the user application for resource management.
 *
 *******************************************************************************/
-#define XAie_InstDeclare(Inst, ConfigPtr) XAie_DevInst Inst = { 0 }
+#define XAie_InstDeclare(Inst, ConfigPtr) XAie_DevInst Inst = {}
 
 /*****************************************************************************/
 /**


### PR DESCRIPTION
The XAie_InstDeclare define declares a structure, but didn't completely initialize it.  This patch initializes the structure to a default value.