### PR TITLE
Fix name of external symbol AmdairBackend

### DIFF
--- a/driver/src/io_backend/ext/xaie_amdair.c
+++ b/driver/src/io_backend/ext/xaie_amdair.c
@@ -596,7 +596,7 @@ static u64 XAie_AmdAirGetTid(void)
 #endif
 }
 
-const XAie_Backend AmdAirBackend =
+const XAie_Backend AmdairBackend =
 {
 	.Type = XAIE_IO_BACKEND_AMDAIR,
 	.Ops.Init = XAie_AmdAirIO_Init,


### PR DESCRIPTION
This PR fixes the error encountered when compiling the `mlir-air` tests described here https://github.com/Xilinx/mlir-air/issues/431.