### PR TITLE
enable debug backend

### DIFF
--- a/driver/src/io_backend/xaie_io.c
+++ b/driver/src/io_backend/xaie_io.c
@@ -85,11 +85,7 @@
 #else
 	#define AMDAIRBACKEND NULL
 #endif
-#if defined (__AIEDEBUG__)
-	#define DEBUGBACKEND &DebugBackend
-#else
-	#define DEBUGBACKEND NULL
-#endif
+#define DEBUGBACKEND &DebugBackend
 
 /************************** Variable Definitions *****************************/
 extern const XAie_Backend MetalBackend;


### PR DESCRIPTION
There's no way to use the debug backend without recompiling even though it's always there anyway (the same goes for the rest of the backends so maybe we want to move `AMDAIRBACKEND &AmdairBackend` out of these weird `#if` as well @eddierichter-amd).