### PR TITLE
Strix 2024.2 AMDAIR fix

### DIFF
--- a/driver/src/Makefile.Linux
+++ b/driver/src/Makefile.Linux
@@ -15,7 +15,7 @@ DOCS_DIR = ../tmp
 DOXYGEN_CONFIG_FILE = ../docs/aie_driver_docs_config.dox
 
 OUTS = $(LIBSOURCES:.c=.o)
-INCLUDEFILES = ./*/xaie_clock.h ./*/xaie_reset.h ./*/xaie_core.h ./*/xaie_dma.h ./*/xaie_elfloader.h ./*/xaie_events.h ./*/xaie_events_aie.h ./*/xaie_events_aieml.h ./*/xaie_interrupt.h ./*/xaie_lite.h ./*/xaie_lite_util.h ./*/xaie_locks.h ./*/xaie_mem.h ./*/xaie_perfcnt.h ./*/xaie_plif.h ./*/xaie_rsc.h ./*/xaie_ss.h ./*/xaie_timer.h ./*/xaie_trace.h ./*/xaie_util_events.h ./*/xaiegbl.h ./*/xaiegbl_defs.h ./*/xaiegbl_dynlink.h ./*/xaiegbl_regdef.h ./*/xaie_io.h ./*/xaie_feature_config.h ./*/xaie_helper.h ./*/xaie_lite_hwcfg.h ./*/xaiegbl_params.h ./xaiengine.h ./*/xaie_txn.h
+INCLUDEFILES = ./*/xaie_clock.h ./*/xaie_reset.h ./*/xaie_core.h ./*/xaie_dma.h ./*/xaie_elfloader.h ./*/xaie_events.h ./*/xaie_events_aie.h ./*/xaie_events_aieml.h ./*/xaie_interrupt.h ./*/xaie_lite.h ./*/xaie_lite_util.h ./*/xaie_locks.h ./*/xaie_mem.h ./*/xaie_perfcnt.h ./*/xaie_plif.h ./*/xaie_rsc.h ./*/xaie_ss.h ./*/xaie_timer.h ./*/xaie_trace.h ./*/xaie_util_events.h ./*/xaiegbl.h ./*/xaiegbl_defs.h ./*/xaiegbl_dynlink.h ./*/xaiegbl_regdef.h ./*/xaie_io.h ./*/xaie_feature_config.h ./*/xaie_helper.h ./*/xaie_lite_hwcfg.h ./*/xaiegbl_params.h ./*/xaie_txn.h
 INTERNALFILES = ./*/*.h ./*/*/*.h
 INCLUDEDIR = ../include
 INTERNALDIR = ../internal

--- a/driver/src/io_backend/ext/xaie_amdair.c
+++ b/driver/src/io_backend/ext/xaie_amdair.c
@@ -596,7 +596,7 @@ static u64 XAie_AmdAirGetTid(void)
 #endif
 }
 
-const XAie_Backend AmdairBackend =
+const XAie_Backend AmdAirBackend =
 {
 	.Type = XAIE_IO_BACKEND_AMDAIR,
 	.Ops.Init = XAie_AmdAirIO_Init,

--- a/driver/src/io_backend/xaie_io.c
+++ b/driver/src/io_backend/xaie_io.c
@@ -81,7 +81,7 @@
 	#define SOCKETBACKEND NULL
 #endif
 #if defined (__AIEAMDAIR__)
-	#define AMDAIRBACKEND &AmdairBackend
+	#define AMDAIRBACKEND &AmdAirBackend
 #else
 	#define AMDAIRBACKEND NULL
 #endif


### PR DESCRIPTION
This PR contains two changes:

- Fixing AMD AIR backend in . 
- The latest aie-rt organization breaks our CMake flow if we link against an existing install of aie-rt. Specifically generates an error here: https://github.com/Xilinx/mlir-aie/blob/main/runtime_lib/xaiengine/aiert.cmake#L12 because there are multiple targets with the same name. Removed copying over a redundant header file to fix it. 