### PR TITLE
Declare extern functions directly instead of including vitis header

### DIFF
--- a/driver/src/io_backend/ext/xaie_sim.c
+++ b/driver/src/io_backend/ext/xaie_sim.c
@@ -37,7 +37,14 @@
 
 #ifdef __AIESIM__ /* AIE simulator */
 
-#include "main_rts.h"
+#include <stdint.h>
+typedef unsigned int uint;
+
+void ess_Write32(uint64_t Addr, uint Data);
+uint ess_Read32(uint64_t Addr);
+
+void ess_NpiWrite32(uint64_t Addr, uint Data);
+uint ess_NpiRead32(uint64_t Addr);
 
 #endif
 


### PR DESCRIPTION
So that the library can be compiled with `__AIESIM__` defined without Vitis present. Vitis is still needed to _run_ simulations, this just removes the build time dependence.