### PR TITLE
Add declarations for clang/msvc builds

### DIFF
--- a/driver/src/io_backend/ext/xaie_sim.c
+++ b/driver/src/io_backend/ext/xaie_sim.c
@@ -38,10 +38,13 @@
 #ifdef __AIESIM__ /* AIE simulator */
 
 #include <stdint.h>
+#include <unistd.h>
+
 typedef unsigned int uint;
 
 void ess_Write32(uint64_t Addr, uint Data);
 uint ess_Read32(uint64_t Addr);
+void ess_WriteCmd(unsigned char Command, unsigned char ColId, unsigned char RowId, unsigned int CmdWd0, unsigned int CmdWd1, unsigned char *CmdStr);
 
 void ess_NpiWrite32(uint64_t Addr, uint Data);
 uint ess_NpiRead32(uint64_t Addr);


### PR DESCRIPTION
Compiling with not gcc and `__AIESIM__` causes build errors: https://github.com/Xilinx/mlir-aie/actions/runs/17408946426/job/49422596902?pr=2545 