### PR TITLE
Add a workaround for cdo_rts.h

### DIFF
--- a/driver/src/io_backend/ext/xaie_cdo.c
+++ b/driver/src/io_backend/ext/xaie_cdo.c
@@ -29,7 +29,13 @@
 
 #ifdef __AIECDO__ /* AIE simulator */
 
-#include "cdo_rts.h"
+#include "stdint.h"
+
+void cdo_Write32(uint64_t, uint32_t);
+void cdo_MaskWrite32(uint64_t , uint32_t, uint32_t);
+void cdo_MaskPoll(uint64_t , uint32_t, uint32_t, uint32_t);
+void cdo_BlockWrite32(uint64_t, const uint32_t*, uint32_t);
+void cdo_BlockSet32(uint64_t, uint32_t, uint32_t);
 
 #endif
 


### PR DESCRIPTION
Previously this was handled by patching bootgen, but mlir-aie already maintains [a branch of aie-rt](https://github.com/stephenneuendorffer/aie-rt/tree/strix_2024.2) with a similar patch for simulation "main_rts.h", and patching here allows bootgen to be used by mlir-aie unpatched.

Enables https://github.com/Xilinx/mlir-aie/pull/2822